### PR TITLE
Use multicast-socket for broadcasting mdns messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,8 +90,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc",
- "winapi 0.3.8",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "e4036b9bf40f3cf16aba72a3d65e8a520fc4bafcdc7079aea8f848c58c5b5536"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle",
 ]
 
@@ -119,7 +119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -219,6 +219,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "c_linked_list"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
+
+[[package]]
 name = "cc"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,7 +253,6 @@ dependencies = [
  "async-std",
  "colmeia-dat1",
  "colmeia-dat1-core",
- "colmeia-dat1-mdns",
  "colmeia-dat1-proto",
  "colmeia-hyperswarm-mdns",
  "env_logger",
@@ -343,8 +348,8 @@ dependencies = [
  "hex",
  "lazy_static",
  "log",
+ "multicast-socket",
  "rand",
- "socket2",
  "trust-dns-proto",
 ]
 
@@ -624,6 +629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+
+[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,13 +644,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "get_if_addrs"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
+dependencies = [
+ "c_linked_list",
+ "get_if_addrs-sys",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "get_if_addrs-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
+dependencies = [
+ "gcc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi",
 ]
 
@@ -671,7 +704,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 dependencies = [
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -731,7 +764,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -767,6 +800,11 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.71"
+source = "git+https://github.com/rust-lang/libc#77d522eeda2cbf0befe2c080d0a022c1c2a2e338"
 
 [[package]]
 name = "libc"
@@ -835,7 +873,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "miow",
  "net2",
@@ -862,14 +900,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864e1de64c29b386d2dc7822aea156a7e4d45d4393ac748878dc21c9c41037f0"
 
 [[package]]
+name = "multicast-socket"
+version = "0.1.0"
+source = "git+https://github.com/bltavares/multicast-socket.git#4f1a75a4a40ad98d7a743e079349c7e6fceceb18"
+dependencies = [
+ "get_if_addrs",
+ "libc 0.2.71 (git+https://github.com/rust-lang/libc)",
+ "nix",
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 dependencies = [
  "cfg-if",
- "libc",
- "winapi 0.3.8",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "git+https://github.com/bltavares/nix?branch=sendmsg-pktinfo-android#0a97376ec2dc69c2efc49f7962db00004e59c2e1"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc 0.2.71 (git+https://github.com/rust-lang/libc)",
 ]
 
 [[package]]
@@ -885,7 +946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1050,7 +1111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha",
  "rand_core",
  "rand_hc",
@@ -1256,7 +1317,7 @@ dependencies = [
  "crossbeam-utils",
  "futures-io",
  "futures-util",
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
  "piper",
  "scoped-tls-hkt",
@@ -1272,9 +1333,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1331,7 +1392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5d8ef1b679c07976f3ee336a436453760c470f54b5e7237556728b8589515d"
 dependencies = [
  "error-chain",
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "time",
 ]
@@ -1380,9 +1441,9 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 dependencies = [
- "libc",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1596,9 +1657,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -1622,7 +1683,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 [[package]]
 name = "libc"
 version = "0.2.71"
-source = "git+https://github.com/rust-lang/libc#77d522eeda2cbf0befe2c080d0a022c1c2a2e338"
+source = "git+https://github.com/rust-lang/libc#0c2027f05a3a4053b37a72f88a9da2af02d30621"
 
 [[package]]
 name = "libc"
@@ -902,7 +902,7 @@ checksum = "864e1de64c29b386d2dc7822aea156a7e4d45d4393ac748878dc21c9c41037f0"
 [[package]]
 name = "multicast-socket"
 version = "0.1.0"
-source = "git+https://github.com/bltavares/multicast-socket.git#4f1a75a4a40ad98d7a743e079349c7e6fceceb18"
+source = "git+https://github.com/bltavares/multicast-socket.git#89065dd3c919c2d636d2348c9f84573e77127fc4"
 dependencies = [
  "get_if_addrs",
  "libc 0.2.71 (git+https://github.com/rust-lang/libc)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 
 [workspace]
 members = [
-    'colmeia-dat1-mdns',
+    # 'colmeia-dat1-mdns',
     'colmeia-dat1-proto',
     'colmeia-dat1-core',
     'colmeia-dat1',
@@ -24,8 +24,8 @@ anyhow = '*'
 version = '1.6.0'
 features = ['unstable']
 
-[dependencies.colmeia-dat1-mdns]
-path = 'colmeia-dat1-mdns'
+# [dependencies.colmeia-dat1-mdns]
+# path = 'colmeia-dat1-mdns'
 
 [dependencies.colmeia-dat1-proto]
 path = 'colmeia-dat1-proto'

--- a/colmeia-hyperswarm-mdns/Cargo.toml
+++ b/colmeia-hyperswarm-mdns/Cargo.toml
@@ -7,12 +7,14 @@ edition = '2018'
 [dependencies]
 hex = '0.4.2'
 trust-dns-proto = '0.19.5'
-socket2 = '0.3.12'
 lazy_static = '1.4.0'
 log = '0.4.8'
 futures = '0.3.5'
-anyhow = "1.0.31"
-rand = "0.7.3"
+anyhow = '1.0.31'
+rand = '0.7.3'
+
+[dependencies.multicast-socket]
+git = 'https://github.com/bltavares/multicast-socket.git'
 
 [dependencies.async-std]
 version = '1.6.0'

--- a/colmeia-hyperswarm-mdns/src/lib.rs
+++ b/colmeia-hyperswarm-mdns/src/lib.rs
@@ -72,7 +72,7 @@ impl MdnsDiscovery {
     }
 
     pub fn with_locator(&mut self, duration: Duration) -> &mut Self {
-        self.locate = crate::socket::create_shared()
+        self.locate = crate::socket::create()
             .map_err(anyhow::Error::from)
             .and_then(|socket| {
                 locator::Locator::with_identifier(
@@ -88,7 +88,7 @@ impl MdnsDiscovery {
     }
 
     pub fn with_announcer(&mut self, port: u16) -> &mut Self {
-        self.announce = crate::socket::create_shared()
+        self.announce = crate::socket::create()
             .map_err(anyhow::Error::from)
             .and_then(|socket| {
                 announcer::Announcer::with_identifier(

--- a/colmeia-hyperswarm-mdns/src/locator.rs
+++ b/colmeia-hyperswarm-mdns/src/locator.rs
@@ -1,8 +1,8 @@
 use anyhow::Context;
-use async_std::net::UdpSocket as AsyncUdpSocket;
 use async_std::stream::StreamExt;
 use async_std::task;
 use futures::{stream, Stream};
+use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -28,31 +28,22 @@ pub fn packet(hyperswarm_domain: Name) -> anyhow::Result<Vec<u8>> {
     Ok(buffer)
 }
 
-async fn broadcast(hyperswarm_domain: Name, socket: &AsyncUdpSocket) -> anyhow::Result<()> {
+async fn broadcast(
+    hyperswarm_domain: Name,
+    socket: Arc<multicast_socket::MulticastSocket>,
+) -> anyhow::Result<()> {
     let mdns_packet_bytes = packet(hyperswarm_domain)?;
-
-    socket
-        .send_to(&mdns_packet_bytes, *crate::socket::MULTICAST_DESTINATION)
+    task::spawn(async move { socket.broadcast(&mdns_packet_bytes) })
         .await
         .context("could not send packet to multicast address")?;
 
     Ok(())
 }
 
-// Only works for ipv4 mdns
-async fn wait_response(socket: &AsyncUdpSocket) -> anyhow::Result<(Vec<u8>, Ipv4Addr)> {
-    let mut buffer = [0; 512];
-    let (read_size, origin_ip) = socket.recv_from(&mut buffer).await?;
-
-    if let SocketAddr::V4(origin_ip) = origin_ip {
-        let packet_data: Vec<_> = buffer.iter().take(read_size).cloned().collect();
-        return Ok((packet_data, *origin_ip.ip()));
-    }
-
-    Err(anyhow::anyhow!(
-        "packet response is not ipv4, {:?}",
-        origin_ip
-    ))
+async fn wait_response(
+    socket: Arc<multicast_socket::MulticastSocket>,
+) -> io::Result<multicast_socket::Message> {
+    task::spawn(async move { socket.receive() }).await
 }
 
 pub struct Locator {
@@ -62,7 +53,7 @@ pub struct Locator {
 
 impl Locator {
     pub fn new(
-        socket: std::net::UdpSocket,
+        socket: multicast_socket::MulticastSocket,
         hash: &[u8],
         announcement_window: Duration,
     ) -> anyhow::Result<Self> {
@@ -70,19 +61,19 @@ impl Locator {
     }
 
     pub fn with_identifier(
-        socket: std::net::UdpSocket,
+        socket: multicast_socket::MulticastSocket,
         hash: &[u8],
         self_id: String,
         announcement_window: Duration,
     ) -> anyhow::Result<Self> {
         let self_id: crate::OwnedSelfId = [self_id.into_bytes().into_boxed_slice()];
         let hyperswarm_domain = crate::hash_as_domain_name(hash)?;
-        let socket = Arc::from(AsyncUdpSocket::from(socket));
+        let socket = Arc::from(socket);
 
         let broadcast_stream = stream::unfold(
             (hyperswarm_domain.clone(), socket.clone()),
             |(hyperswarm_domain, socket)| async move {
-                let broadcast_result = broadcast(hyperswarm_domain.clone(), &socket).await;
+                let broadcast_result = broadcast(hyperswarm_domain.clone(), socket.clone()).await;
                 if let Err(problem) = broadcast_result {
                     log::warn!(
                         "failed to broadcast a packet. trying again later. {:?}",
@@ -95,12 +86,17 @@ impl Locator {
         .throttle(announcement_window);
 
         let response_stream = stream::unfold(socket, |socket| async {
-            let response = wait_response(&socket).await;
+            let response = wait_response(socket.clone()).await;
             Some((response, socket))
         })
         .filter_map(|item| item.ok())
-        .filter_map(move |(packet, origin_ip)| {
-            select_ip_from_hyperswarm_mdns_response(packet, origin_ip, &hyperswarm_domain, &self_id)
+        .filter_map(move |message| {
+            select_ip_from_hyperswarm_mdns_response(
+                message.data,
+                message.origin_address.ip(),
+                &hyperswarm_domain,
+                &self_id,
+            )
         });
 
         Ok(Locator {
@@ -112,7 +108,7 @@ impl Locator {
 
 fn select_ip_from_hyperswarm_mdns_response(
     packet: Vec<u8>,
-    origin_ip: Ipv4Addr,
+    origin_ip: &Ipv4Addr,
     hyperswarm_domain: &Name,
     self_id: crate::SelfId,
 ) -> Option<SocketAddr> {
@@ -135,7 +131,7 @@ fn select_ip_from_hyperswarm_mdns_response(
     if let RData::SRV(srv_data) = srv_matches.rdata() {
         let port = srv_data.port();
         if srv_data.target() == &*crate::UNSPECIFIED_NAME {
-            return Some(SocketAddr::new(IpAddr::V4(origin_ip), port));
+            return Some(SocketAddr::new(IpAddr::V4(*origin_ip), port));
         } else {
             let target_ipv4 = srv_data.target().to_utf8().parse::<Ipv4Addr>().ok()?;
             return Some(SocketAddr::new(IpAddr::V4(target_ipv4), port));

--- a/colmeia-hyperswarm-mdns/src/socket.rs
+++ b/colmeia-hyperswarm-mdns/src/socket.rs
@@ -1,49 +1,12 @@
-use socket2::{Domain, Protocol, Socket, Type};
+use multicast_socket::MulticastSocket;
 use std::io;
-use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
-use std::time::Duration;
+use std::net::{Ipv4Addr, SocketAddrV4};
 
-const IPV4_MULTICAST: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
+const MDNS_IP: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
 lazy_static::lazy_static! {
-  pub static ref MULTICAST_DESTINATION: SocketAddr = SocketAddr::new(IPV4_MULTICAST.into(), 5353);
-  static ref DAT_MULTICAST: SocketAddr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 5353);
+  pub static ref MDNS_ADDRESS: SocketAddrV4 = SocketAddrV4::new(MDNS_IP, 5353);
 }
 
-/// On Windows, unlike all Unix variants, it is improper to bind to the multicast address
-///
-/// see https://msdn.microsoft.com/en-us/library/windows/desktop/ms737550(v=vs.85).aspx
-#[cfg(windows)]
-fn bind_multicast(socket: &Socket, addr: &SocketAddr) -> io::Result<()> {
-    // TODO Likelly a source of problems for computers with multiple interfaces on windows
-    // I had way to many problems already with windows selecting the WSL interface to broadcast
-    // instead of the wired interface to talk to my other server on the "real" LAN
-    let addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), addr.port());
-    socket.bind(&socket2::SockAddr::from(addr))
-}
-
-/// On unixes we bind to the multicast address, which causes multicast packets to be filtered
-#[cfg(unix)]
-fn bind_multicast(socket: &Socket, addr: &SocketAddr) -> io::Result<()> {
-    socket.bind(&socket2::SockAddr::from(*addr))
-}
-
-/// Only Unix has this setup
-#[cfg(unix)]
-fn reuse_port(socket: &Socket) -> io::Result<()> {
-    socket.set_reuse_port(true)
-}
-
-#[cfg(windows)]
-fn reuse_port(_socket: &Socket) -> io::Result<()> {
-    Ok(())
-}
-
-pub fn create_shared() -> Result<UdpSocket, io::Error> {
-    let socket = Socket::new(Domain::ipv4(), Type::dgram(), Some(Protocol::udp()))?;
-    socket.set_read_timeout(Some(Duration::from_millis(100)))?;
-    socket.set_reuse_address(true)?;
-    reuse_port(&socket)?;
-    socket.join_multicast_v4(&IPV4_MULTICAST, &Ipv4Addr::UNSPECIFIED)?;
-    bind_multicast(&socket, &DAT_MULTICAST)?;
-    Ok(socket.into_udp_socket())
+pub(crate) fn create() -> io::Result<MulticastSocket> {
+    MulticastSocket::all_interfaces(*MDNS_ADDRESS)
 }

--- a/src/bin/colmeia-mdns.rs
+++ b/src/bin/colmeia-mdns.rs
@@ -1,29 +1,33 @@
-use colmeia_dat1_mdns::Mdns;
-use futures::stream::StreamExt;
-use std::time::Duration;
+// use colmeia_dat1_mdns::Mdns;
+// use futures::stream::StreamExt;
+// use std::time::Duration;
 
-fn name() -> String {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    args.first().expect("must have dat name as argument").into()
-}
+// fn name() -> String {
+//     let args: Vec<String> = std::env::args().skip(1).collect();
+//     args.first().expect("must have dat name as argument").into()
+// }
+
+// fn main() {
+//     env_logger::init();
+
+//     let name = name();
+
+//     async_std::task::block_on(async {
+//         let dat_key = colmeia_dat1_core::parse(&name).expect("invalid dat argument");
+//         let dat_key = match dat_key {
+//             colmeia_dat1_core::DatUrlResolution::HashUrl(result) => result,
+//             _ => panic!("invalid hash key"),
+//         };
+//         let mut mdns = Mdns::new(dat_key);
+//         mdns.with_announcer(3282)
+//             .with_location(Duration::from_secs(10));
+
+//         while let Some(peer) = mdns.next().await {
+//             println!("Peer found {:?}", peer);
+//         }
+//     })
+// }
 
 fn main() {
-    env_logger::init();
 
-    let name = name();
-
-    async_std::task::block_on(async {
-        let dat_key = colmeia_dat1_core::parse(&name).expect("invalid dat argument");
-        let dat_key = match dat_key {
-            colmeia_dat1_core::DatUrlResolution::HashUrl(result) => result,
-            _ => panic!("invalid hash key"),
-        };
-        let mut mdns = Mdns::new(dat_key);
-        mdns.with_announcer(3282)
-            .with_location(Duration::from_secs(10));
-
-        while let Some(peer) = mdns.next().await {
-            println!("Peer found {:?}", peer);
-        }
-    })
 }


### PR DESCRIPTION
This commit introduces
[multicast-socket](https://github.com/bltavares/multicast-socket) as the
underlying socket implementation for mdns discovery.

It is allowing to listen and broadcast messages on multiple interfaces.
Tested and working:

- Win x Linux (WSL) discovery
- Same host Linux (WSL) discovery

Not working:
- Same Win discovery

Partially working:
- Win x Linux (WSL) discovery - Origin address returns 0.0.0.0

Fixes #15 