### PR TITLE
Support handling multiple feeds on MDNS discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -266,7 +266,7 @@ checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
  "cfg-if",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
@@ -487,6 +487,7 @@ dependencies = [
  "futures",
  "hex",
  "hypercore-protocol",
+ "log",
 ]
 
 [[package]]
@@ -945,7 +946,7 @@ checksum = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
 dependencies = [
  "c_linked_list",
  "get_if_addrs-sys",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "winapi 0.2.8",
 ]
 
@@ -956,7 +957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
 dependencies = [
  "gcc",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
@@ -966,7 +967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "wasi",
 ]
 
@@ -1031,7 +1032,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
@@ -1184,7 +1185,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
@@ -1238,14 +1239,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.72"
-source = "git+https://github.com/rust-lang/libc#9f581e6256e90db1c47b76f13193c532d3406c07"
-
-[[package]]
-name = "libc"
-version = "0.2.72"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "log"
@@ -1319,7 +1315,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "log",
  "miow",
  "net2",
@@ -1347,11 +1343,12 @@ checksum = "864e1de64c29b386d2dc7822aea156a7e4d45d4393ac748878dc21c9c41037f0"
 
 [[package]]
 name = "multicast-socket"
-version = "0.1.0"
-source = "git+https://github.com/bltavares/multicast-socket.git#89065dd3c919c2d636d2348c9f84573e77127fc4"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4165a42af1448862a88ff0f706890484eb67e95c571aedfe677155e002967970"
 dependencies = [
  "get_if_addrs",
- "libc 0.2.72 (git+https://github.com/rust-lang/libc)",
+ "libc",
  "nix",
  "socket2",
  "winapi 0.3.9",
@@ -1370,19 +1367,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "nix"
-version = "0.17.0"
-source = "git+https://github.com/bltavares/nix?branch=sendmsg-pktinfo-android#0a97376ec2dc69c2efc49f7962db00004e59c2e1"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
- "libc 0.2.72 (git+https://github.com/rust-lang/libc)",
+ "libc",
 ]
 
 [[package]]
@@ -1398,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
@@ -1642,7 +1640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "rand_chacha",
  "rand_core",
  "rand_hc",
@@ -1927,7 +1925,7 @@ dependencies = [
  "fastrand",
  "futures-io",
  "futures-util",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "once_cell",
  "scoped-tls",
  "slab",
@@ -1960,7 +1958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
  "cfg-if",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "redox_syscall",
  "winapi 0.3.9",
 ]
@@ -2098,7 +2096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "rand",
  "redox_syscall",
  "remove_dir_all",
@@ -2171,7 +2169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
 dependencies = [
  "cfg-if",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "standback",
  "stdweb",
  "time-macros",
@@ -2436,7 +2434,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 [dependencies]
 futures = '*'
 env_logger = '*'
+log = '*'
 hex = '*'
 anyhow = '*'
 ed25519-dalek = '=1.0.0-pre.3'

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Uses NOISE protocol and a different handshake.
 
 #### Protocol
 
-- [ ] **wip** `colmeia-hypercore**: Networked module for hypercore storage
+- [ ] **wip** `colmeia-hypercore`: Networked module for hypercore storage
   - [ ] Clone metadata into a hypercore feed
   - [ ] Hypercore and Hyperfeed impl
   - [ ] Use metadata to clone content hypercore feed ([first block is content public key](https://github.com/hypercore-protocol/hyperdrive/blob/v10.13.0/index.js#L186))

--- a/colmeia-hypercore/src/hyperstack.rs
+++ b/colmeia-hypercore/src/hyperstack.rs
@@ -26,7 +26,7 @@ where
     hyperdrive: Arc<RwLock<Hyperdrive<Storage>>>,
     connected_peers: Arc<RwLock<HashSet<SocketAddr>>>,
     listen_address: SocketAddr,
-    discovery: Option<Box<dyn Stream<Item = SocketAddr> + Unpin + Send>>,
+    discovery: Option<Box<dyn Stream<Item = (Vec<u8>, SocketAddr)> + Unpin + Send>>,
 }
 
 impl Hyperstack<random_access_disk::RandomAccessDisk> {
@@ -70,7 +70,7 @@ where
         + Send
         + Sync,
 {
-    pub async fn lan(&self) -> anyhow::Result<impl Stream<Item = SocketAddr>> {
+    pub async fn lan(&self) -> anyhow::Result<impl Stream<Item = (Vec<u8>, SocketAddr)>> {
         let mut mdns = colmeia_hyperswarm_mdns::MdnsDiscovery::new();
         mdns.with_announcer(self.listen_address.port())
             .with_locator(Duration::from_secs(60));
@@ -81,7 +81,7 @@ where
 
     pub fn with_discovery(
         &mut self,
-        mechanisms: impl Stream<Item = SocketAddr> + Unpin + 'static + Send,
+        mechanisms: impl Stream<Item = (Vec<u8>, SocketAddr)> + Unpin + 'static + Send,
     ) -> &mut Self {
         self.discovery = Some(Box::new(mechanisms));
         self
@@ -105,7 +105,7 @@ where
         async move {
             let discovery = match discovery {
                 Some(mut discovery) => task::spawn(async move {
-                    while let Some(peer) = discovery.next().await {
+                    while let Some((_, peer)) = discovery.next().await {
                         if !discovery_connected_peers.read().await.contains(&peer) {
                             let driver = discovery_driver.clone();
                             let connected_peers = discovery_connected_peers.clone();

--- a/colmeia-hypercore/src/lib.rs
+++ b/colmeia-hypercore/src/lib.rs
@@ -6,5 +6,5 @@ mod utils;
 
 pub use hyperdrive::{in_memmory, Hyperdrive};
 pub use hyperstack::Hyperstack;
-pub use network::{PeeredFeed, replicate_hyperdrive, Emit};
+pub use network::{replicate_hyperdrive, Emit, PeeredFeed};
 pub use utils::{HashParserError, PublicKeyExt};

--- a/colmeia-hyperswarm-mdns/Cargo.toml
+++ b/colmeia-hyperswarm-mdns/Cargo.toml
@@ -12,9 +12,7 @@ log = '0.4.8'
 futures = '0.3.5'
 anyhow = '1.0.31'
 rand = '0.7.3'
-
-[dependencies.multicast-socket]
-git = 'https://github.com/bltavares/multicast-socket.git'
+multicast-socket = '0.2.0'
 
 [dependencies.async-std]
 version = '1.6.0'

--- a/colmeia-hyperswarm-mdns/src/announcer.rs
+++ b/colmeia-hyperswarm-mdns/src/announcer.rs
@@ -114,10 +114,8 @@ impl Announcer {
                             .iter()
                             .find(|name| is_same_hash_questions(&message.data, name).is_some())
                         {
-                            log::debug!(
-                                "Announce received {:?}",
-                                sender.send(*message.origin_address.ip()).await
-                            );
+                            let result = sender.send(*message.origin_address.ip()).await;
+                            log::debug!("Announce received {:?}", result);
                             let reply = respond(
                                 (*name).clone(),
                                 message.interface,

--- a/colmeia-hyperswarm-mdns/src/announcer.rs
+++ b/colmeia-hyperswarm-mdns/src/announcer.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
-use async_std::{stream::StreamExt, task};
-use futures::{stream, stream::StreamExt as FStreamExt, FutureExt, Stream};
+use async_std::{sync::RwLock, task};
+use futures::{stream::StreamExt as FStreamExt, SinkExt, Stream};
 use trust_dns_proto::op::{Message, MessageType};
 use trust_dns_proto::rr::{
     rdata::{SRV, TXT},
@@ -10,7 +10,7 @@ use trust_dns_proto::serialize::binary::{BinEncodable, BinEncoder};
 
 use std::io;
 use std::sync::Arc;
-use std::{net::Ipv4Addr, pin::Pin};
+use std::{collections::HashSet, net::Ipv4Addr, pin::Pin};
 
 pub fn packet(
     hyperswarm_domain: Name,
@@ -86,74 +86,73 @@ fn is_same_hash_questions(packet: &[u8], hyperswarm_domain: &Name) -> Option<Mes
     Some(dns_message)
 }
 
-type ListenContext = (
-    multicast_socket::Message,
-    Arc<multicast_socket::MulticastSocket>,
-);
-
 pub struct Announcer {
-    stream: Pin<Box<dyn Stream<Item = Ipv4Addr> + Send>>,
+    topics: Arc<RwLock<HashSet<Name>>>,
+    _listener_job: task::JoinHandle<()>,
+    stream: Box<dyn Stream<Item = Ipv4Addr> + Unpin + Send + Sync>,
 }
 
 impl Announcer {
-    pub fn new(
+    pub fn listen(
         socket: multicast_socket::MulticastSocket,
-        hash: &[u8],
-        port: u16,
-    ) -> anyhow::Result<Self> {
-        Announcer::with_identifier(socket, hash, port, crate::self_id())
-    }
-
-    pub fn with_identifier(
-        socket: multicast_socket::MulticastSocket,
-        hash: &[u8],
         port: u16,
         self_identifier: String,
-    ) -> anyhow::Result<Self> {
-        let hyperswarm_domain = Arc::from(crate::hash_as_domain_name(hash)?);
+    ) -> Self {
+        let topics: Arc<RwLock<HashSet<Name>>> = Default::default();
         let socket = Arc::from(socket);
 
-        let listener = stream::unfold(socket, |socket| async {
-            let response = wait_broadcast(socket.clone()).await;
-            Some((response.map(|msg| (msg, socket.clone())), socket))
-        });
+        let (mut sender, receiver) = futures::channel::mpsc::unbounded();
+        let listener_job = {
+            let topics = topics.clone();
 
-        let listen_stream = StreamExt::filter_map(listener, |i| i.ok());
+            task::spawn(async move {
+                loop {
+                    if let Ok(message) = wait_broadcast(socket.clone()).await {
+                        if let Some(name) = topics
+                            .read()
+                            .await
+                            .iter()
+                            .find(|name| is_same_hash_questions(&message.data, name).is_some())
+                        {
+                            log::debug!(
+                                "Announce received {:?}",
+                                sender.send(*message.origin_address.ip()).await
+                            );
+                            let reply = respond(
+                                (*name).clone(),
+                                message.interface,
+                                socket.clone(),
+                                port,
+                                self_identifier.clone(),
+                            )
+                            .await;
 
-        let select_packets_fn = {
-            let name = hyperswarm_domain.clone();
-            move |(message, _): &ListenContext| {
-                is_same_hash_questions(&message.data, &name).is_some()
-            }
+                            if let Err(e) = reply {
+                                log::warn!("Could not send response back {}", e);
+                            }
+                        }
+                    }
+                }
+            })
         };
-        let listen_stream = StreamExt::filter(listen_stream, select_packets_fn);
 
-        let response_fn = {
-            let name = hyperswarm_domain.clone();
-            move |(message, socket): ListenContext| {
-                let result = respond(
-                    (*name).clone(),
-                    message.interface,
-                    socket,
-                    port,
-                    self_identifier.clone(),
-                );
-                let origin_address = message.origin_address;
-                result.map(move |i| (i, origin_address))
-            }
-        };
-        let listen_stream = StreamExt::map(listen_stream, response_fn);
-        let listen_stream = FStreamExt::then(listen_stream, |result| async {
-            let (result, origin_address) = result.await;
-            if let Err(e) = result {
-                log::warn!("Could not send response back {}", e);
-            }
-            *origin_address.ip()
-        });
+        Self {
+            topics,
+            _listener_job: listener_job,
+            stream: Box::new(receiver),
+        }
+    }
 
-        Ok(Announcer {
-            stream: Box::pin(listen_stream),
-        })
+    pub async fn add_topic(&self, topic: &[u8]) -> anyhow::Result<()> {
+        let value = crate::hash_as_domain_name(topic)?;
+        self.topics.write().await.insert(value);
+        Ok(())
+    }
+
+    pub async fn remove_topic(&self, topic: &[u8]) -> anyhow::Result<()> {
+        let value = crate::hash_as_domain_name(topic)?;
+        self.topics.write().await.remove(&value);
+        Ok(())
     }
 }
 
@@ -163,7 +162,6 @@ impl futures::Stream for Announcer {
         mut self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
     ) -> task::Poll<Option<Self::Item>> {
-        use futures::stream::StreamExt;
         self.stream.poll_next_unpin(cx)
     }
 }

--- a/colmeia-hyperswarm-mdns/src/lib.rs
+++ b/colmeia-hyperswarm-mdns/src/lib.rs
@@ -105,7 +105,7 @@ impl MdnsDiscovery {
 }
 
 impl Stream for MdnsDiscovery {
-    type Item = SocketAddr;
+    type Item = (Vec<u8>, SocketAddr);
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         if let Some(ref mut announcer) = &mut self.announce {

--- a/colmeia-hyperswarm-mdns/src/lib.rs
+++ b/colmeia-hyperswarm-mdns/src/lib.rs
@@ -108,7 +108,6 @@ impl Stream for MdnsDiscovery {
     type Item = SocketAddr;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-
         if let Some(ref mut announcer) = &mut self.announce {
             let _ = announcer.poll_next_unpin(cx);
         };
@@ -118,5 +117,11 @@ impl Stream for MdnsDiscovery {
         }
 
         Poll::Pending
+    }
+}
+
+impl Default for MdnsDiscovery {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/colmeia-hyperswarm-mdns/src/locator.rs
+++ b/colmeia-hyperswarm-mdns/src/locator.rs
@@ -98,7 +98,8 @@ impl Locator {
                             );
 
                             if let Some(peer) = found {
-                                log::debug!("Announce received {:?}", sender.send(peer).await);
+                                let result = sender.send(peer).await;
+                                log::debug!("Announce received {:?}: {:?}", peer, result);
                             }
                         }
                     }

--- a/colmeiad/src/main.rs
+++ b/colmeiad/src/main.rs
@@ -73,7 +73,11 @@ async fn main() -> Result<(), std::io::Error> {
     let mut hyperstack = Hyperstack::in_memory(hash, "0.0.0.0:3899".parse().unwrap())
         .await
         .expect("Could not start hyperdrive on the stack");
-    hyperstack.with_discovery(hyperstack.lan());
+    let mdns = hyperstack
+        .lan()
+        .await
+        .expect("could not add key to mdns discovery");
+    hyperstack.with_discovery(mdns);
 
     let job = task::spawn(hyperstack.replicate());
     let hyperdrive = hyperstack.hyperdrive();

--- a/src/bin/colmeia-hyperswarm-mdns.rs
+++ b/src/bin/colmeia-hyperswarm-mdns.rs
@@ -1,7 +1,7 @@
 use async_std::{prelude::FutureExt, prelude::StreamExt, sync::RwLock, task};
 use colmeia_hypercore::PublicKeyExt;
 use colmeia_hyperswarm_mdns::MdnsDiscovery;
-use std::{env, net::Ipv4Addr, net::SocketAddr};
+use std::env;
 use std::{sync::Arc, time::Duration};
 
 // 7e5998407b3d9dbb94db21ff50ad6f1b1d2c79e476fbaf9856c342eb4382e7f5

--- a/src/bin/colmeia-sync.rs
+++ b/src/bin/colmeia-sync.rs
@@ -24,8 +24,8 @@ fn main() {
         let mut hyperstack = Hyperstack::in_memory(hash, "0.0.0.0:3899".parse().unwrap())
             .await
             .expect("Could not start hyperdrive on the stack");
-        hyperstack.with_discovery(hyperstack.lan());
-
+        let mdns = hyperstack.lan().await.expect("could not configure mdns");
+        hyperstack.with_discovery(mdns);
         hyperstack.replicate().await;
     });
 }


### PR DESCRIPTION
This commit allow us to add and remove feed itens from the mDNS
discovery stack.

We are not capable of integrating with @Frando's `hypercore-replicator`,
which should let us introduce new discovery feeds when looking on mdns.

The binary example tests that we can still have a stream of items, and
that we can add and remove topics in the background.

Ideally, we could later move into the "subscribers" direction, instead
of a single stream, similar to how @Frando is doing on the `hyperspace`
code. So we can avoid wrapping things on a `Arc<RwLock<_>>`.

TODO: Refactor Hyperstack - possibly using `hypercore-replicator` and
move out the `hyperdrive` into it's own crate.

Closes #22